### PR TITLE
feat: Support minute second typed strings

### DIFF
--- a/python_libs/pc_lib/pc_snap.py
+++ b/python_libs/pc_lib/pc_snap.py
@@ -330,6 +330,11 @@ class Drop_Operator(bpy.types.Operator):
             if event.type == 'BACK_SPACE':
                 if self.typed_value != "":
                     self.typed_value = self.typed_value[:-1]
+            if event.type == 'QUOTE':
+                if event.shift:
+                    self.typed_value += '"'
+                else:
+                    self.typed_value += "'"
 
     def set_placed_properties(self,obj):
         if obj.type == 'MESH' and 'IS_OPENING_MESH' not in obj:

--- a/python_libs/pc_lib/pc_unit.py
+++ b/python_libs/pc_lib/pc_unit.py
@@ -1,6 +1,7 @@
 '''
 Common Unit Conversion Functions
 '''
+import re
 import bpy
 from decimal import *
 
@@ -84,3 +85,17 @@ def unit_to_string(unit_settings,value):
             return str(round(meter_to_inch(value),4)) + '"'
     else:
         return str(round(value,4))
+
+def parse_feet_and_inches(input_str):
+    # Define a regular expression pattern to match feet and inches notation with optional parts
+    pattern = re.compile(r'^(?:(?P<feet>\d+)\')?(?:(?P<inches>\d+)\"?)?$')
+
+    # Use regular expression to extract feet and inches
+    match = pattern.match(input_str)
+
+    if match:
+        feet = int(match.group('feet')) if match.group('feet') else 0
+        inches = int(match.group('inches')) if match.group('inches') else 0
+        return feet, inches
+    else:
+        raise ValueError(f"Invalid input format. Please use the format X'Y\" or X' or Y\". Got {input_str}")

--- a/walls/wall_ops.py
+++ b/walls/wall_ops.py
@@ -86,10 +86,17 @@ class home_builder_OT_draw_multiple_walls(pc_snap.Drop_Operator):
     ht_cancel_command = "(RIGHT CLICK or ESC = Exit Command)"
     ht_close_room = "(C = Close Room)"
     ht_set_angle = "(HOLD ALT = Set Angle)"
-    ht_type_numbers = "(Type numbers to set wall Length)"
     ht_start = ht_start_command + ht_space + ht_cancel_command
-    ht_second_click = ht_next_click_command + ht_space + ht_type_numbers + ht_space + ht_set_angle + ht_space + ht_cancel_command
-    ht_forth_click = ht_next_click_command + ht_space + ht_close_room + ht_space + ht_type_numbers + ht_space + ht_set_angle + ht_space + ht_cancel_command
+
+    def ht_forth_click(self):
+        ht_type_numbers = f"(Type numbers to set wall Length): {self.typed_value}"
+        message = self.ht_next_click_command + self.ht_space + self.ht_close_room + self.ht_space + ht_type_numbers + self.ht_space + self.ht_set_angle + self.ht_space + self.ht_cancel_command
+        return message
+
+    def ht_second_click(self):
+        ht_type_numbers = f"(Type numbers to set wall Length): {self.typed_value}"
+        message = self.ht_next_click_command + self.ht_space + ht_type_numbers + self.ht_space + self.ht_set_angle + self.ht_space + self.ht_cancel_command
+        return message
 
     def reset_properties(self):
         self.current_wall = None
@@ -274,9 +281,9 @@ class home_builder_OT_draw_multiple_walls(pc_snap.Drop_Operator):
         else:
             self.dim.obj.hide_viewport = False
             if number_of_walls > 1:
-                context.workspace.status_text_set(text=self.ht_forth_click)
+                context.workspace.status_text_set(text=self.ht_forth_click())
             else:
-                context.workspace.status_text_set(text=self.ht_second_click)
+                context.workspace.status_text_set(text=self.ht_second_click())
 
         if self.starting_point == () and connected_wall_bp:
             previous_wall = pc_types.Assembly(connected_wall_bp)
@@ -310,11 +317,11 @@ class home_builder_OT_draw_multiple_walls(pc_snap.Drop_Operator):
                 if dist < self.distance_to_snap_to_end:
                     self.previous_wall = previous_wall
                     self.connect_walls()
-                self.typed_value = ""                
+                self.typed_value = ""
             return {'RUNNING_MODAL'}
-            
+
         if self.event_is_place_next_point(event):
-            context.workspace.status_text_set(text=self.ht_second_click)
+            context.workspace.status_text_set(text=self.ht_second_click())
             pc_utils.delete_object_and_children(self.dim.obj)
             self.set_placed_properties(self.current_wall.obj_bp)
             self.create_wall()

--- a/walls/wall_ops.py
+++ b/walls/wall_ops.py
@@ -398,14 +398,15 @@ class home_builder_OT_draw_multiple_walls(pc_snap.Drop_Operator):
         if self.typed_value == "":
             self.current_wall.obj_x.location.x = math.fabs(length)
         else:
-            if self.typed_value == ".":
-                value = 0
-            else:
-                value = eval(self.typed_value)
             if bpy.context.scene.unit_settings.system == 'METRIC':
+                if self.typed_value == ".":
+                    value = 0
+                else:
+                    value = eval(self.typed_value)
                 self.current_wall.obj_x.location.x = pc_unit.millimeter(float(value))
             else:
-                self.current_wall.obj_x.location.x = pc_unit.inch(float(value))     
+                feet, inches = pc_unit.parse_feet_and_inches(self.typed_value)
+                self.current_wall.obj_x.location.x = pc_unit.inch(feet * 12 + inches)
 
     def get_snap_location(self,selected_point):
         sv = bpy.context.scene.home_builder.wall_distance_snap_value


### PR DESCRIPTION
### Context:

Adding the ability to use minute (`'`) and second (`"`) annotation for typed input when building walls.
What I ended up doing is if you don't put a minute or second annotation in you'll default to inches.  If you specify just the minute annotation the next digit is considered a second operation and can be unit less.

I also updated the status bar to show the live typed input.

In Imperial mode:

`12` -> 12 inches
`12'` -> 12 feet
`12'6` -> 12 feet 6 inches
`12'6"` -> 12 feet 6 inches
`9"` -> 9 inches

Doesn't affect metric mode.